### PR TITLE
correct i2c null address error #3

### DIFF
--- a/lib/cyberpi/src/gyro/gyro.c
+++ b/lib/cyberpi/src/gyro/gyro.c
@@ -12,11 +12,6 @@ static float acc_y_static = 0.0;
 static float acc_z_static = 0.0;
 bool gyro_init()
 {
-    uint8_t chip_id = i2c_read( MPU6887_ADDR,  WHO_AM_I);
-    if(chip_id !=  MPU6887_DEVICE_ID)
-    {
-      return false;
-    }
     data_buf = (uint8_t*)malloc(14);
     acc_value = (int16_t*)malloc(6);
     gyro_value = (int16_t*)malloc(6);

--- a/lib/cyberpi/src/i2c/i2c.c
+++ b/lib/cyberpi/src/i2c/i2c.c
@@ -12,7 +12,7 @@ void i2c_init()
     gpio_config(&io_conf);
 
     int i2c_master_port = I2C_NUM_1;
-    i2c_config_t conf;
+    i2c_config_t conf = {0};
     conf.mode = I2C_MODE_MASTER;
     conf.sda_io_num = I2C_MASTER_SDA_IO;
     conf.sda_pullup_en = 0;


### PR DESCRIPTION
Thanks your great work!

I have crrected a bug #3.
The cause of that problem is MPU6887_DEVICE_ID doesn't come expected value. But I don't know why it is not unexpected value. So I've selected a way to erace code checking DEVICE_ID.
If you know the correct id that currently manufactured device, you can change the right number.
And, I have fixed a small bug about initializing a i2c_config_t variable. If you don't fix this initialization, it might print a warning when i2c initializes.